### PR TITLE
Fix misleading UVC state log

### DIFF
--- a/esphome/components/mspa_wifi/mspa_wifi.cpp
+++ b/esphome/components/mspa_wifi/mspa_wifi.cpp
@@ -326,12 +326,12 @@ namespace esphome
           if (mspa_->uvc_switch_) {
             mspa_->uvc_switch_->publish_state(mspa_->actual_state_.uvc);
           }
-        } else {
+        } else if (uvc_enabled != mspa_->actual_state_.uvc) {
           packet[2] = mspa_->actual_state_.uvc ? 0x01 : 0x00;
           fill_crc(packet);
         }
 
-        ESP_LOGI(TAG, "%s: UVC enabled: %s", name_, uvc_enabled ? "true" : "false");
+        ESP_LOGI(TAG, "%s: UVC enabled: %s", name_, mspa_->actual_state_.uvc ? "true" : "false");
         break;
       }
       case CMD_GET_TIMER:


### PR DESCRIPTION
## Summary
- Log UVC state from `actual_state_` instead of the remote packet byte, matching heater, filter, and ozone handlers
- Only rewrite UVC packets when remote and HA states differ (`else if`, matching ozone)

When UVC is controlled from Home Assistant, the remote keeps syncing its own (stale) state. The old log showed the remote packet value, so HA toggles appeared to have no effect even though the correct packets were forwarded to the control box.

## Test plan
- [x] Enable/disable UVC from HA — log shows correct `UVC enabled: true/false`
- [x] Enable/disable UVC from remote — switch state and logs stay in sync
- [x] Verify forwarded packets are unchanged (`A5 15 01 BB` / `A5 15 00 BA`)

Fixes johannesc/mspa-wifi#15