### PR TITLE
Add jet/hydromassage support (command 0x0D)

### DIFF
--- a/esphome/components/mspa_wifi/__init__.py
+++ b/esphome/components/mspa_wifi/__init__.py
@@ -29,6 +29,7 @@ LOCAL_CONF_UART_BOX_TO_REMOTE_ID = "uart_box_to_remote_id"
 LOCAL_CONF_UART_REMOTE_TO_BOX_ID = "uart_remote_to_box_id"
 
 LOCAL_CONV_UVC_COMMAND = "uvc_command"
+LOCAL_CONV_JET_COMMAND = "jet_command"
 
 LOCAL_CONF_FLOW_IN = "flow_in"
 LOCAL_CONF_FLOW_OUT = "flow_out"
@@ -38,6 +39,7 @@ LOCAL_CONF_FILTER_PUMP = "filter_pump"
 LOCAL_CONF_UVC = "uvc"
 LOCAL_CONF_OZONE = "ozone"
 LOCAL_CONF_HEATER = "heater"
+LOCAL_CONF_JET = "jet"
 LOCAL_CONF_INFLATE = "inflate"
 
 LOCAL_CONF_TARGET_WATER_TEMPERATURE = "target_water_temperature"
@@ -112,6 +114,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Required(LOCAL_CONF_UART_BOX_TO_REMOTE_ID): cv.use_id(uart.UARTComponent),
         cv.Required(LOCAL_CONF_UART_REMOTE_TO_BOX_ID): cv.use_id(uart.UARTComponent),
         cv.Optional(LOCAL_CONV_UVC_COMMAND, default=0x15): cv.one_of(0x10, 0x15, int),
+        cv.Optional(LOCAL_CONV_JET_COMMAND, default=0x0D): cv.hex_int_range(min=0x01, max=0xFF),
         cv.Optional(LOCAL_CONF_FLOW_IN): FLOW_IN_SCHEMA,
         cv.Optional(LOCAL_CONF_FLOW_OUT): FLOW_OUT_SCHEMA,
         cv.Optional(LOCAL_CONF_FILTER_PUMP): switch.switch_schema(
@@ -125,6 +128,9 @@ CONFIG_SCHEMA = cv.Schema(
         ),
         cv.Optional(LOCAL_CONF_HEATER): switch.switch_schema(
             MspaSwitch, icon=ICON_LIGHTBULB
+        ),
+        cv.Optional(LOCAL_CONF_JET): switch.switch_schema(
+            MspaSwitch, icon="mdi:water-pump"
         ),
         cv.Optional(LOCAL_CONF_INFLATE): switch.switch_schema(
             MspaSwitch, icon="mdi:pump"
@@ -157,6 +163,9 @@ async def to_code(config):
     # Configuration
     if LOCAL_CONV_UVC_COMMAND in config:
         cg.add(var.set_uvc_command(config[LOCAL_CONV_UVC_COMMAND]))
+
+    if LOCAL_CONV_JET_COMMAND in config:
+        cg.add(var.set_jet_command(config[LOCAL_CONV_JET_COMMAND]))
 
     # Sensors
     if LOCAL_CONF_FLOW_IN in config:
@@ -209,6 +218,7 @@ async def to_code(config):
             LOCAL_CONF_HEATER: "HEATER",
             LOCAL_CONF_UVC: "UVC",
             LOCAL_CONF_OZONE: "OZONE",
+            LOCAL_CONF_JET: "JET",
             LOCAL_CONF_INFLATE: "INFLATE",
         }.items():
         sw = await switch.new_switch(config[conf])

--- a/esphome/components/mspa_wifi/mspa_switch.cpp
+++ b/esphome/components/mspa_wifi/mspa_switch.cpp
@@ -32,6 +32,10 @@ namespace esphome
                 ESP_LOGI(TAG, "Ozone enable %s", state ? "true" : "false");
                 mspa_->set_ozone(state);
                 break;
+            case MspaSwitchType::JET:
+                ESP_LOGI(TAG, "Jet enable %s", state ? "true" : "false");
+                mspa_->set_jet(state);
+                break;
             case MspaSwitchType::INFLATE:
                 ESP_LOGI(TAG, "Inflate enable %s", state ? "true" : "false");
                 mspa_->set_inflate(state);

--- a/esphome/components/mspa_wifi/mspa_switch.h
+++ b/esphome/components/mspa_wifi/mspa_switch.h
@@ -16,6 +16,7 @@ namespace esphome
       FILTER,
       UVC,
       OZONE,
+      JET,
       INFLATE,
     };
     typedef void (*set_state_func)();

--- a/esphome/components/mspa_wifi/mspa_wifi.cpp
+++ b/esphome/components/mspa_wifi/mspa_wifi.cpp
@@ -16,8 +16,9 @@
 #define CMD_SET_TARGET_TEMP 0x04
 #define CMD_GET_TIMER 0x0B
 #define CMD_SET_OZONE 0x0E
-#define CMD_SET_UNKNOWN_0D 0x0D
+#define CMD_SET_JET 0x0D
 #define CMD_SET_INFLATE 0x16
+#define CMD_JET_REPORT 0x18
 
 #define TAG "MspaWifi"
 
@@ -30,7 +31,7 @@ namespace esphome
     }
 
     void MspaWifi::set_remote_to_box_uart(uart::UARTComponent *remote_uart) {
-      mspa_remote_to_box_ = new MspaRemoteToBoxCom(remote_uart, this, uvc_command_, "<--");
+      mspa_remote_to_box_ = new MspaRemoteToBoxCom(remote_uart, this, uvc_command_, jet_command_, "<--");
     }
 
     void MspaWifi::MspaCom::fill_crc(uint8_t *packet)
@@ -71,6 +72,13 @@ namespace esphome
         set_filter(true); // UVC requires filter pump running, also enable that
       }
       mspa_remote_to_box_->set_uvc(enabled);
+    }
+
+    void MspaWifi::set_jet(bool enabled) {
+      if (enabled) {
+        set_filter(true); // Jet requires filter pump running, also enable that
+      }
+      mspa_remote_to_box_->set_jet(enabled);
     }
 
     void MspaWifi::set_inflate(bool enabled) {
@@ -122,6 +130,7 @@ namespace esphome
     {
       ESP_LOGI(TAG, "Set filter %s", enabled ? "ENABLE" : "DISABLE");
       mspa_->actual_state_.filter = enabled; // This will be used in handle_packet
+      mspa_->remote_state_.filter = enabled; // Keep in sync to prevent F1
       if (mspa_->filter_pump_switch_ != NULL) {
         mspa_->filter_pump_switch_->publish_state(mspa_->actual_state_.filter);
       }
@@ -153,6 +162,19 @@ namespace esphome
       }
       uint8_t data = enabled ? 1 : 0;
       uint8_t packet[MSPA_PACKET_LEN] = {MSPA_START_BYTE, uvc_command_, data, 0};
+      fill_crc(packet);
+      send_packet(packet);
+    }
+
+    void MspaWifi::MspaRemoteToBoxCom::set_jet(bool enabled)
+    {
+      ESP_LOGI(TAG, "Set jet %s", enabled ? "ENABLE" : "DISABLE");
+      mspa_->actual_state_.jet = enabled; // This will be used in handle_packet
+      if (mspa_->jet_switch_) {
+        mspa_->jet_switch_->publish_state(mspa_->actual_state_.jet);
+      }
+      uint8_t data = enabled ? 1 : 0;
+      uint8_t packet[MSPA_PACKET_LEN] = {MSPA_START_BYTE, jet_command_, data, 0};
       fill_crc(packet);
       send_packet(packet);
     }
@@ -216,6 +238,12 @@ namespace esphome
       {
         ESP_LOGI(TAG, "%s: Timer report: %02X", name_, packet[2]);
         break;
+      }
+      case CMD_JET_REPORT:
+      {
+        ESP_LOGI(TAG, "%s: Jet report: %02X", name_, packet[2]);
+        // Don't forward to remote - it causes F1 when jets were activated from HA
+        return;
       }
       default:
       {
@@ -339,10 +367,22 @@ namespace esphome
         ESP_LOGI(TAG, "%s: Get timer", name_);
         break;
       }
-      case CMD_SET_UNKNOWN_0D:
+      case CMD_SET_JET:
       {
-        bool unknown_enabled = packet[2] == 0x01;
-        ESP_LOGI(TAG, "%s: Set unknown %s", name_, unknown_enabled ? "true" : "false");
+        bool jet_enabled = packet[2] == 0x01;
+        if (jet_enabled != mspa_->remote_state_.jet) {
+          // Jet was changed at the remote
+          // The remote is now "in control"
+          mspa_->remote_state_.jet = jet_enabled;
+          mspa_->actual_state_.jet = jet_enabled;
+          if (mspa_->jet_switch_) {
+            mspa_->jet_switch_->publish_state(mspa_->actual_state_.jet);
+          }
+        } else if (jet_enabled != mspa_->actual_state_.jet) {
+          packet[2] = mspa_->actual_state_.jet ? 0x01 : 0x00;
+          fill_crc(packet);
+        }
+        ESP_LOGI(TAG, "%s: Jet enabled: %s", name_, mspa_->actual_state_.jet ? "true" : "false");
         break;
       }
       case CMD_SET_INFLATE:

--- a/esphome/components/mspa_wifi/mspa_wifi.h
+++ b/esphome/components/mspa_wifi/mspa_wifi.h
@@ -11,6 +11,7 @@
 
 #define CMD_SET_UVC_ALT_1 0x10
 #define CMD_SET_UVC_ALT_2 0x15
+#define CMD_SET_JET_DEFAULT 0x0D
 
 namespace esphome
 {
@@ -54,11 +55,12 @@ namespace esphome
       class MspaRemoteToBoxCom : public MspaCom
       {
       public:
-        MspaRemoteToBoxCom(uart::UARTComponent *uart, MspaWifi *mspa, uint8_t uvc_command, const char *name)
+        MspaRemoteToBoxCom(uart::UARTComponent *uart, MspaWifi *mspa, uint8_t uvc_command, uint8_t jet_command, const char *name)
           : MspaCom(uart, name)
         {
           mspa_ = mspa;
           uvc_command_ = uvc_command;
+          jet_command_ = jet_command;
         }
 
         void set_target_water_temperature(float target);
@@ -68,6 +70,7 @@ namespace esphome
         void set_filter(bool enabled);
         void set_ozone(bool enabled);
         void set_uvc(bool enabled);
+        void set_jet(bool enabled);
         void set_inflate(bool enabled);
 
       protected:
@@ -77,6 +80,7 @@ namespace esphome
         MspaWifi *mspa_;
 
         uint8_t uvc_command_ = 0;
+        uint8_t jet_command_ = 0;
       };
       class MspaBoxToRemoteCom : public MspaCom
       {
@@ -100,6 +104,7 @@ namespace esphome
         uint8_t bubble;
         bool ozone;
         bool uvc;
+        bool jet;
       } mspa_state_t;
 
       mspa_state_t actual_state_ = {0};
@@ -114,6 +119,7 @@ namespace esphome
       SUB_SWITCH(heater);
       SUB_SWITCH(uvc);
       SUB_SWITCH(ozone);
+      SUB_SWITCH(jet);
       SUB_SWITCH(inflate);
 
     public:
@@ -126,6 +132,7 @@ namespace esphome
       void set_target_water_temperature_number(number::Number *number) { this->target_water_temperature_number_ = number; }
       void set_target_bubble_speed_number(number::Number *number) { this->target_bubble_speed_number_ = number; }
       void set_uvc_command(int command) { this->uvc_command_ = command; }
+      void set_jet_command(int command) { this->jet_command_ = command; }
 
       void set_target_water_temperature(float target);
       void set_bubble_speed(uint8_t speed);
@@ -134,10 +141,12 @@ namespace esphome
       void set_filter(bool enabled);
       void set_ozone(bool enabled);
       void set_uvc(bool enabled);
+      void set_jet(bool enabled);
       void set_inflate(bool enabled);
 
     private:
       uint8_t uvc_command_ = CMD_SET_UVC_ALT_2;
+      uint8_t jet_command_ = CMD_SET_JET_DEFAULT;
 
       number::Number *target_water_temperature_number_{nullptr};
       number::Number *target_bubble_speed_number_{nullptr};

--- a/esphome/mspa-wifi.yaml
+++ b/esphome/mspa-wifi.yaml
@@ -81,6 +81,7 @@ mspa_wifi:
   uart_box_to_remote_id: uart_box_to_remote
   uart_remote_to_box_id: uart_remote_to_box
   uvc_command: 0x15
+  jet_command: 0x0D
 
   # Sensors
   water_temperature:
@@ -121,6 +122,10 @@ mspa_wifi:
   heater:
     id: mspa_heater
     name: "Heater"
+
+  jet:
+    name: "Jet"
+    id: mspa_jet_switch
 
   # Number controls
   target_water_temperature:


### PR DESCRIPTION
- Add jet switch controllable from both HA and physical remote
- Add configurable jet_command (default 0x0D) in YAML
- Handle box jet status report (0x18) without forwarding to remote
- Sync remote_state_.filter when HA activates filter pump
- Switch framework from arduino to esp-idf

Tested on
MSPA Muse Otium M-OT061
LOLIN S2 Mini (ESP32-S2)
ESPHome 2025.7.5